### PR TITLE
Dramatically increase crystallization speed for rain-art and matrix-art

### DIFF
--- a/animations/matrixart.go
+++ b/animations/matrixart.go
@@ -61,7 +61,7 @@ func NewMatrixArtEffect(width, height int, palette []string, text string) *Matri
 		artPositions: make(map[int]map[int]rune),
 		frozenChars:  make(map[int]map[int]*FrozenMatrixChar),
 		rng:          rand.New(rand.NewSource(time.Now().UnixNano())),
-		freezeChance: 0.65, // 65% chance to freeze when passing through art position (fast crystallization)
+		freezeChance: 0.90, // 90% chance to freeze when passing through art position (very fast crystallization)
 	}
 
 	m.parseArt()
@@ -108,9 +108,9 @@ func (m *MatrixArtEffect) parseArt() {
 
 // init initializes matrix streaks
 func (m *MatrixArtEffect) init() {
-	// Create initial streaks across width - much denser than regular matrix
+	// Create initial streaks across width - extremely dense for fast crystallization
 	for i := 0; i < m.width; i++ {
-		if m.rng.Float64() < 0.3 {
+		if m.rng.Float64() < 0.5 {
 			streak := MatrixStreak{
 				X:       i,
 				Y:       -m.rng.Intn(m.height),
@@ -215,8 +215,17 @@ func (m *MatrixArtEffect) Update() {
 	}
 	m.streaks = activeStreaks
 
-	// Add new streaks randomly - much higher spawn rate for dense effect
-	for len(m.streaks) < m.width*2 && m.rng.Float64() < 0.15 {
+	// Count active streaks only
+	activeCount := 0
+	for _, s := range m.streaks {
+		if s.Active {
+			activeCount++
+		}
+	}
+
+	// Keep spawning new streaks to maintain high density - target 4x width
+	maxActiveStreaks := m.width * 4
+	for activeCount < maxActiveStreaks && m.rng.Float64() < 0.4 {
 		x := m.rng.Intn(m.width)
 		streak := MatrixStreak{
 			X:       x,
@@ -227,6 +236,7 @@ func (m *MatrixArtEffect) Update() {
 			Active:  true,
 		}
 		m.streaks = append(m.streaks, streak)
+		activeCount++
 	}
 }
 

--- a/animations/rainart.go
+++ b/animations/rainart.go
@@ -48,7 +48,7 @@ func NewRainArtEffect(width, height int, palette []string, text string) *RainArt
 		artPositions: make(map[int]map[int]rune),
 		frozenChars:  make(map[int]map[int]*FrozenChar),
 		rng:          rand.New(rand.NewSource(time.Now().UnixNano())),
-		freezeChance: 0.60, // 60% chance to freeze when passing through art position (fast crystallization)
+		freezeChance: 0.90, // 90% chance to freeze when passing through art position (very fast crystallization)
 	}
 
 	r.parseArt()


### PR DESCRIPTION
- Rain-art: freeze chance 60% → 90% for much faster crystallization
- Matrix-art: freeze chance 65% → 90%
- Matrix-art: initial spawn density 30% → 50%
- Matrix-art: max active streams 2x width → 4x width (double the streams)
- Matrix-art: spawn rate 15% → 40%
- Fixed matrix stream counting to only count active streams
- Ensures consistent high stream density throughout animation