### PR TITLE
Massively increase stream density for rain-art and matrix-art

### DIFF
--- a/animations/matrixart.go
+++ b/animations/matrixart.go
@@ -108,19 +108,17 @@ func (m *MatrixArtEffect) parseArt() {
 
 // init initializes matrix streaks
 func (m *MatrixArtEffect) init() {
-	// Create initial streaks across width - extremely dense for fast crystallization
-	for i := 0; i < m.width; i++ {
-		if m.rng.Float64() < 0.5 {
-			streak := MatrixStreak{
-				X:       i,
-				Y:       -m.rng.Intn(m.height),
-				Length:  m.rng.Intn(15) + 5,
-				Speed:   m.rng.Intn(3) + 1,
-				Counter: 0,
-				Active:  true,
-			}
-			m.streaks = append(m.streaks, streak)
+	// Create massive initial stream density for very fast crystallization
+	for i := 0; i < m.width*3; i++ {
+		streak := MatrixStreak{
+			X:       m.rng.Intn(m.width),
+			Y:       -m.rng.Intn(m.height),
+			Length:  m.rng.Intn(15) + 5,
+			Speed:   m.rng.Intn(3) + 1,
+			Counter: 0,
+			Active:  true,
 		}
+		m.streaks = append(m.streaks, streak)
 	}
 }
 
@@ -223,9 +221,9 @@ func (m *MatrixArtEffect) Update() {
 		}
 	}
 
-	// Keep spawning new streaks to maintain high density - target 4x width
-	maxActiveStreaks := m.width * 4
-	for activeCount < maxActiveStreaks && m.rng.Float64() < 0.4 {
+	// Keep spawning new streaks to maintain extremely high density - target 6x width
+	maxActiveStreaks := m.width * 6
+	for activeCount < maxActiveStreaks && m.rng.Float64() < 0.5 {
 		x := m.rng.Intn(m.width)
 		streak := MatrixStreak{
 			X:       x,

--- a/animations/rainart.go
+++ b/animations/rainart.go
@@ -43,7 +43,7 @@ func NewRainArtEffect(width, height int, palette []string, text string) *RainArt
 		palette:      palette,
 		chars:        []rune{'|', '⋮', '║', '¦', '┆', '┊', '╎', '╏', '▏', '▎', '▍', '▌', '▋', '▊', '▉'},
 		drops:        make([]RainDrop, 0, 200),
-		maxDrops:     width * 2,
+		maxDrops:     width * 4, // 4x width for very dense rain
 		text:         text,
 		artPositions: make(map[int]map[int]rune),
 		frozenChars:  make(map[int]map[int]*FrozenChar),
@@ -95,8 +95,8 @@ func (r *RainArtEffect) parseArt() {
 
 // init initializes rain drops
 func (r *RainArtEffect) init() {
-	// Create initial drops scattered across width
-	for i := 0; i < r.width/3; i++ {
+	// Create many initial drops for dense rain effect
+	for i := 0; i < r.width*2; i++ {
 		drop := RainDrop{
 			X:     r.rng.Intn(r.width),
 			Y:     -r.rng.Intn(r.height),
@@ -159,8 +159,8 @@ func (r *RainArtEffect) Update() {
 	}
 	r.drops = activeDrops
 
-	// Add new drops randomly
-	for len(r.drops) < r.maxDrops && r.rng.Float64() < 0.3 {
+	// Aggressively spawn new drops to maintain high density
+	for len(r.drops) < r.maxDrops && r.rng.Float64() < 0.5 {
 		drop := RainDrop{
 			X:     r.rng.Intn(r.width),
 			Y:     -r.rng.Intn(10),


### PR DESCRIPTION
Rain-art improvements:
- Max drops: 2x width → 4x width (doubled capacity)
- Initial drops: width/3 → 2x width (6x more starting drops)
- Spawn rate: 30% → 50% (aggressive replenishment)

Matrix-art improvements:
- Initial streams: 50% of width → 3x width (6x denser start)
- Max active streams: 4x width → 6x width (50% more streams)
- Spawn rate: 40% → 50% (faster replenishment)