### PR TITLE
Remove hardcoded ASCII fallbacks, use assets/SYSC.txt

### DIFF
--- a/cmd/syscgo/main.go
+++ b/cmd/syscgo/main.go
@@ -249,30 +249,34 @@ func runMatrixArt(width, height int, theme string, file string, frames int) {
 	// Get theme palette for matrix
 	palette := animations.GetMatrixPalette(theme)
 
-	// Read text from file or use default (SYSC.txt)
-	text := `████████████████████████ ████████        ████████  ████████████████████████ ████████████████████████
-████████████████████████ ████████        ████████  ████████████████████████ ████████████████████████
-████████▒▒▒▒▒▒▒▒████████ ████████        ████████  ████████▒▒▒▒▒▒▒▒████████ ████████▒▒▒▒▒▒▒▒████████
-████████        ████████ ████████        ████████  ████████        ████████ ████████        ████████
-████████        ▒▒▒▒▒▒▒▒ ████████        ████████  ████████        ▒▒▒▒▒▒▒▒ ████████        ▒▒▒▒▒▒▒▒
-████████                 ████████        ████████  ████████                 ████████
-████████████████████████ ████████████████████████  ████████████████████████ ████████
-████████████████████████ ████████████████████████  ████████████████████████ ████████
-▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒████████ ▒▒▒▒▒▒▒▒████████▒▒▒▒▒▒▒▒  ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒████████ ████████
-                ████████         ████████                          ████████ ████████
-████████        ████████         ████████          ████████        ████████ ████████        ████████
-████████        ████████         ████████          ████████        ████████ ████████        ████████
-████████████████████████         ████████          ████████████████████████ ████████████████████████
-████████████████████████         ████████          ████████████████████████ ████████████████████████
-▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒         ▒▒▒▒▒▒▒▒          ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒`
+	// Read text from file or use default assets/SYSC.txt
+	var text string
 
 	if file != "" {
-		data, err := os.ReadFile(file)
-		if err == nil {
+		// Try to read from provided file
+		data, readErr := os.ReadFile(file)
+		if readErr == nil {
 			text = string(data)
 		} else {
-			fmt.Printf("Warning: Could not read file %s, using default text\n", file)
-			time.Sleep(2 * time.Second)
+			// Fall back to assets/SYSC.txt
+			data, readErr = os.ReadFile("assets/SYSC.txt")
+			if readErr == nil {
+				text = string(data)
+				fmt.Printf("Warning: Could not read %s, using assets/SYSC.txt\n", file)
+				time.Sleep(1 * time.Second)
+			} else {
+				fmt.Printf("Error: Could not read file %s or assets/SYSC.txt\n", file)
+				os.Exit(1)
+			}
+		}
+	} else {
+		// No file provided, use assets/SYSC.txt
+		data, readErr := os.ReadFile("assets/SYSC.txt")
+		if readErr == nil {
+			text = string(data)
+		} else {
+			fmt.Println("Error: Could not read assets/SYSC.txt")
+			os.Exit(1)
 		}
 	}
 
@@ -327,30 +331,34 @@ func runRainArt(width, height int, theme string, file string, frames int) {
 	// Get theme palette for rain
 	palette := animations.GetRainPalette(theme)
 
-	// Read text from file or use default (SYSC.txt)
-	text := `████████████████████████ ████████        ████████  ████████████████████████ ████████████████████████
-████████████████████████ ████████        ████████  ████████████████████████ ████████████████████████
-████████▒▒▒▒▒▒▒▒████████ ████████        ████████  ████████▒▒▒▒▒▒▒▒████████ ████████▒▒▒▒▒▒▒▒████████
-████████        ████████ ████████        ████████  ████████        ████████ ████████        ████████
-████████        ▒▒▒▒▒▒▒▒ ████████        ████████  ████████        ▒▒▒▒▒▒▒▒ ████████        ▒▒▒▒▒▒▒▒
-████████                 ████████        ████████  ████████                 ████████
-████████████████████████ ████████████████████████  ████████████████████████ ████████
-████████████████████████ ████████████████████████  ████████████████████████ ████████
-▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒████████ ▒▒▒▒▒▒▒▒████████▒▒▒▒▒▒▒▒  ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒████████ ████████
-                ████████         ████████                          ████████ ████████
-████████        ████████         ████████          ████████        ████████ ████████        ████████
-████████        ████████         ████████          ████████        ████████ ████████        ████████
-████████████████████████         ████████          ████████████████████████ ████████████████████████
-████████████████████████         ████████          ████████████████████████ ████████████████████████
-▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒         ▒▒▒▒▒▒▒▒          ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒`
+	// Read text from file or use default assets/SYSC.txt
+	var text string
 
 	if file != "" {
-		data, err := os.ReadFile(file)
-		if err == nil {
+		// Try to read from provided file
+		data, readErr := os.ReadFile(file)
+		if readErr == nil {
 			text = string(data)
 		} else {
-			fmt.Printf("Warning: Could not read file %s, using default text\n", file)
-			time.Sleep(2 * time.Second)
+			// Fall back to assets/SYSC.txt
+			data, readErr = os.ReadFile("assets/SYSC.txt")
+			if readErr == nil {
+				text = string(data)
+				fmt.Printf("Warning: Could not read %s, using assets/SYSC.txt\n", file)
+				time.Sleep(1 * time.Second)
+			} else {
+				fmt.Printf("Error: Could not read file %s or assets/SYSC.txt\n", file)
+				os.Exit(1)
+			}
+		}
+	} else {
+		// No file provided, use assets/SYSC.txt
+		data, readErr := os.ReadFile("assets/SYSC.txt")
+		if readErr == nil {
+			text = string(data)
+		} else {
+			fmt.Println("Error: Could not read assets/SYSC.txt")
+			os.Exit(1)
 		}
 	}
 
@@ -742,30 +750,34 @@ func runRingText(width, height int, theme string, file string, frames int) {
 		finalGradientStops = []string{"#4A4A4A", "#00D1FF", "#FFFFFF"}
 	}
 
-	// Read text from file or use default (SYSC.txt)
-	text := `████████████████████████ ████████        ████████  ████████████████████████ ████████████████████████
-████████████████████████ ████████        ████████  ████████████████████████ ████████████████████████
-████████▒▒▒▒▒▒▒▒████████ ████████        ████████  ████████▒▒▒▒▒▒▒▒████████ ████████▒▒▒▒▒▒▒▒████████
-████████        ████████ ████████        ████████  ████████        ████████ ████████        ████████
-████████        ▒▒▒▒▒▒▒▒ ████████        ████████  ████████        ▒▒▒▒▒▒▒▒ ████████        ▒▒▒▒▒▒▒▒
-████████                 ████████        ████████  ████████                 ████████
-████████████████████████ ████████████████████████  ████████████████████████ ████████
-████████████████████████ ████████████████████████  ████████████████████████ ████████
-▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒████████ ▒▒▒▒▒▒▒▒████████▒▒▒▒▒▒▒▒  ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒████████ ████████
-                ████████         ████████                          ████████ ████████
-████████        ████████         ████████          ████████        ████████ ████████        ████████
-████████        ████████         ████████          ████████        ████████ ████████        ████████
-████████████████████████         ████████          ████████████████████████ ████████████████████████
-████████████████████████         ████████          ████████████████████████ ████████████████████████
-▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒         ▒▒▒▒▒▒▒▒          ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒`
+	// Read text from file or use default assets/SYSC.txt
+	var text string
 
 	if file != "" {
-		data, err := os.ReadFile(file)
-		if err == nil {
+		// Try to read from provided file
+		data, readErr := os.ReadFile(file)
+		if readErr == nil {
 			text = string(data)
 		} else {
-			fmt.Printf("Warning: Could not read file %s, using default text\n", file)
-			time.Sleep(2 * time.Second)
+			// Fall back to assets/SYSC.txt
+			data, readErr = os.ReadFile("assets/SYSC.txt")
+			if readErr == nil {
+				text = string(data)
+				fmt.Printf("Warning: Could not read %s, using assets/SYSC.txt\n", file)
+				time.Sleep(1 * time.Second)
+			} else {
+				fmt.Printf("Error: Could not read file %s or assets/SYSC.txt\n", file)
+				os.Exit(1)
+			}
+		}
+	} else {
+		// No file provided, use assets/SYSC.txt
+		data, readErr := os.ReadFile("assets/SYSC.txt")
+		if readErr == nil {
+			text = string(data)
+		} else {
+			fmt.Println("Error: Could not read assets/SYSC.txt")
+			os.Exit(1)
 		}
 	}
 
@@ -851,36 +863,28 @@ func runBlackhole(width, height int, theme string, file string, frames int) {
 
 	// Read text from file
 	// If file is empty string, use empty text (triggers particle generation)
-	// Otherwise read from file or use default SYSC text
+	// Otherwise read from file or use default assets/SYSC.txt
 	var text string
 
 	if file == "" {
 		// Empty file means generate random particles (no text)
 		text = ""
 	} else {
-		// Try to read from file, or use default SYSC text
-		data, err := os.ReadFile(file)
-		if err == nil {
+		// Try to read from provided file
+		data, readErr := os.ReadFile(file)
+		if readErr == nil {
 			text = string(data)
 		} else {
-			// Default SYSC text
-			fmt.Printf("Warning: Could not read file %s, using default SYSC text\n", file)
-			time.Sleep(2 * time.Second)
-			text = `████████████████████████ ████████        ████████  ████████████████████████ ████████████████████████
-████████████████████████ ████████        ████████  ████████████████████████ ████████████████████████
-████████▒▒▒▒▒▒▒▒████████ ████████        ████████  ████████▒▒▒▒▒▒▒▒████████ ████████▒▒▒▒▒▒▒▒████████
-████████        ████████ ████████        ████████  ████████        ████████ ████████        ████████
-████████        ▒▒▒▒▒▒▒▒ ████████        ████████  ████████        ▒▒▒▒▒▒▒▒ ████████        ▒▒▒▒▒▒▒▒
-████████                 ████████        ████████  ████████                 ████████
-████████████████████████ ████████████████████████  ████████████████████████ ████████
-████████████████████████ ████████████████████████  ████████████████████████ ████████
-▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒████████ ▒▒▒▒▒▒▒▒████████▒▒▒▒▒▒▒▒  ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒████████ ████████
-                ████████         ████████                          ████████ ████████
-████████        ████████         ████████          ████████        ████████ ████████        ████████
-████████        ████████         ████████          ████████        ████████ ████████        ████████
-████████████████████████         ████████          ████████████████████████ ████████████████████████
-████████████████████████         ████████          ████████████████████████ ████████████████████████
-▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒         ▒▒▒▒▒▒▒▒          ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒ ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒`
+			// Fall back to assets/SYSC.txt
+			data, readErr = os.ReadFile("assets/SYSC.txt")
+			if readErr == nil {
+				text = string(data)
+				fmt.Printf("Warning: Could not read %s, using assets/SYSC.txt\n", file)
+				time.Sleep(1 * time.Second)
+			} else {
+				fmt.Printf("Error: Could not read file %s or assets/SYSC.txt\n", file)
+				os.Exit(1)
+			}
 		}
 	}
 


### PR DESCRIPTION
- Updated runMatrixArt to load from assets/SYSC.txt by default
- Updated runRainArt to load from assets/SYSC.txt by default
- Updated runRingText to load from assets/SYSC.txt by default
- Updated runBlackhole to load from assets/SYSC.txt by default
- All text effects now follow same pattern:
  1. Try to read from provided file
  2. Fall back to assets/SYSC.txt on error
  3. Show clear error and exit if both fail
- Removed 60+ lines of ugly hardcoded SYSC ASCII from source
- Cleaner codebase with consistent file loading logic

Merged from claude/sysc-go-ring-animation-011CUujHNt8VCfcQhG8vD6KT