### PR TITLE
Remove guidance border and all padding for minimal UI

### DIFF
--- a/tui/model.go
+++ b/tui/model.go
@@ -255,15 +255,11 @@ func NewStyles() Styles {
 			MarginBottom(1),
 
 		GuidanceBox: lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder()).
-			BorderForeground(lipgloss.Color("#4C566A")).
-			Padding(0, 2).
-			MarginTop(1).
-			Foreground(lipgloss.Color("#D8DEE9")),
+			Foreground(lipgloss.Color("#D8DEE9")).
+			Align(lipgloss.Center),
 
 		Help: lipgloss.NewStyle().
 			Foreground(lipgloss.Color("#4C566A")).
-			Padding(1, 0).
 			Align(lipgloss.Center),
 
 		Background: lipgloss.NewStyle(),

--- a/tui/update.go
+++ b/tui/update.go
@@ -28,8 +28,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Canvas takes up maximum available screen space
-		// UI elements (selectors, guidance, help) are now ultra-compact, leaving ~7 lines overhead
-		m.canvasHeight = m.height - 7  // Maximized viewport - compact selectors save space
+		// UI elements are ultra-minimal: Selectors (4 lines) + Guidance (1 line) + Help (1 line) = 6 total
+		m.canvasHeight = m.height - 6  // Maximized viewport - absolute minimal UI overhead
 		if m.canvasHeight < 20 {
 			m.canvasHeight = 20 // Minimum viewport height
 		}


### PR DESCRIPTION
UI Space Reduction:
- Removed GuidanceBox border (saves 2 lines)
- Removed GuidanceBox padding and margin (saves 1 line)
- Removed Help padding (saves 2 lines)
- Total: 5 lines saved

New UI Overhead:
- Selectors: 4 lines (2-line height × 1 row)
- Guidance: 1 line (plain text, no border)
- Help: 1 line (plain text, no padding)
- Total: 6 lines (was 11 lines before)