### PR TITLE
Fix viewport top cutoff by accounting for canvas border

### DIFF
--- a/tui/update.go
+++ b/tui/update.go
@@ -28,8 +28,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Canvas takes up maximum available screen space
-		// UI elements are ultra-minimal: Selectors (4 lines) + Guidance (1 line) + Help (1 line) = 6 total
-		m.canvasHeight = m.height - 6  // Maximized viewport - absolute minimal UI overhead
+		// Total overhead: Border (2) + Selectors (4) + Guidance (1) + Help (1) = 8 lines
+		m.canvasHeight = m.height - 8  // Account for canvas border + UI elements
 		if m.canvasHeight < 20 {
 			m.canvasHeight = 20 // Minimum viewport height
 		}

--- a/tui/view.go
+++ b/tui/view.go
@@ -67,11 +67,10 @@ func (m Model) renderCanvas() string {
 
 	// Wrap raw content in a styled box WITHOUT transforming the content itself
 	// Pattern from sysc-greet: border provides structure, content stays raw
-	// Minimal padding to maximize viewport space
+	// No padding - lipgloss adds enough space with the border
 	return lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(lipgloss.Color("#88C0D0")).
-		Padding(0, 1).
 		Render(content)
 }
 


### PR DESCRIPTION
Canvas Height Calculation Fix:
- Changed from m.height - 6 to m.height - 8
- Now accounts for canvas border (2 lines)
- Total overhead: Border (2) + Selectors (4) + Guidance (1) + Help (1) = 8 lines
- Viewport should now fit perfectly within terminal bounds

Remove Canvas Padding:
- Removed Padding(0, 1) from canvas style
- Lipgloss border already provides visual spacing
- Eliminates potential source of inconsistent left/right padding
- Maximizes animation display area