### PR TITLE
Add fire-text animation with ASCII art negative space effect

### DIFF
--- a/animations/firetext.go
+++ b/animations/firetext.go
@@ -1,0 +1,253 @@
+package animations
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+)
+
+// FireTextEffect implements fire animation with ASCII art displayed as negative space
+// Fire burns around the text, creating text shape with empty areas
+type FireTextEffect struct {
+	width   int      // Terminal width
+	height  int      // Terminal height
+	buffer  []int    // Heat values (0-65), size = width * height
+	palette []string // Hex color codes from theme
+	chars   []rune   // Fire characters for density (8-level gradient)
+
+	// Text masking
+	text         string
+	textMask     [][]bool // [y][x] = true if character exists at this position
+	centerX      int
+	centerY      int
+	artWidth     int
+	artHeight    int
+}
+
+// NewFireTextEffect creates a new fire-text effect with given dimensions, palette, and ASCII art
+func NewFireTextEffect(width, height int, palette []string, text string) *FireTextEffect {
+	f := &FireTextEffect{
+		width:   width,
+		height:  height,
+		palette: palette,
+		text:    text,
+		// Enhanced 8-character gradient for smoother fire rendering
+		chars: []rune{' ', '░', '░', '▒', '▒', '▓', '▓', '█'},
+	}
+	f.parseText()
+	f.init()
+	return f
+}
+
+// parseText extracts ASCII art character positions and creates mask
+func (f *FireTextEffect) parseText() {
+	lines := strings.Split(f.text, "\n")
+	f.artHeight = len(lines)
+
+	// Find max line width
+	f.artWidth = 0
+	for _, line := range lines {
+		if len([]rune(line)) > f.artWidth {
+			f.artWidth = len([]rune(line))
+		}
+	}
+
+	// Center the art
+	f.centerX = (f.width - f.artWidth) / 2
+	f.centerY = (f.height - f.artHeight) / 2
+
+	// Initialize mask
+	f.textMask = make([][]bool, f.height)
+	for i := range f.textMask {
+		f.textMask[i] = make([]bool, f.width)
+	}
+
+	// Mark character positions in mask
+	for lineIdx, line := range lines {
+		lineRunes := []rune(line)
+		for charIdx, char := range lineRunes {
+			if char != ' ' && char != '\n' {
+				x := f.centerX + charIdx
+				y := f.centerY + lineIdx
+
+				// Only mark if within bounds
+				if x >= 0 && x < f.width && y >= 0 && y < f.height {
+					f.textMask[y][x] = true
+				}
+			}
+		}
+	}
+}
+
+// Initialize fire buffer with bottom row as heat source
+func (f *FireTextEffect) init() {
+	f.buffer = make([]int, f.width*f.height)
+
+	// Set bottom row to maximum heat (fire source)
+	// Don't place fire where text is
+	for i := 0; i < f.width; i++ {
+		if !f.textMask[f.height-1][i] {
+			f.buffer[(f.height-1)*f.width+i] = 65
+		}
+	}
+}
+
+// UpdatePalette changes the fire color palette (for theme switching)
+func (f *FireTextEffect) UpdatePalette(palette []string) {
+	f.palette = palette
+}
+
+// Resize reinitializes the fire effect with new dimensions
+func (f *FireTextEffect) Resize(width, height int) {
+	f.width = width
+	f.height = height
+	f.parseText() // Re-parse to recenter text
+	f.init()
+}
+
+// spreadFire propagates heat upward with random decay, respecting text mask
+func (f *FireTextEffect) spreadFire(from int) {
+	fromY := from / f.width
+	fromX := from % f.width
+
+	// Don't spread fire from masked positions
+	if f.textMask[fromY][fromX] {
+		f.buffer[from] = 0 // Ensure masked areas stay cold
+		return
+	}
+
+	// Random horizontal offset (0-3) for flickering effect
+	offset := rand.Intn(4)
+	to := from - f.width - offset + 1
+
+	// Bounds check
+	if to < 0 || to >= len(f.buffer) {
+		return
+	}
+
+	toY := to / f.width
+	toX := to % f.width
+
+	// Don't spread fire TO masked positions (this creates the negative space)
+	if toY >= 0 && toY < f.height && toX >= 0 && toX < f.width {
+		if f.textMask[toY][toX] {
+			return // Fire cannot enter text areas
+		}
+	}
+
+	// Random decay (0-3) for natural fade
+	decay := rand.Intn(4)
+
+	newHeat := f.buffer[from] - decay
+	if newHeat < 0 {
+		newHeat = 0
+	}
+
+	f.buffer[to] = newHeat
+}
+
+// Update advances the fire simulation by one frame
+func (f *FireTextEffect) Update() {
+	// Process all pixels from bottom to top
+	// (Fire spreads upward, must process bottom row first)
+	for y := f.height - 1; y > 0; y-- {
+		for x := 0; x < f.width; x++ {
+			index := y*f.width + x
+			f.spreadFire(index)
+		}
+	}
+
+	// Ensure masked areas stay cold (no fire)
+	for y := 0; y < f.height; y++ {
+		for x := 0; x < f.width; x++ {
+			if f.textMask[y][x] {
+				f.buffer[y*f.width+x] = 0
+			}
+		}
+	}
+}
+
+// Render converts fire to colored block output with batched raw ANSI codes
+// Text areas are rendered as empty space (negative space effect)
+func (f *FireTextEffect) Render() string {
+	var output strings.Builder
+
+	// Always render full viewport height to anchor fire at bottom
+	for y := 0; y < f.height; y++ {
+		var currentColor string
+		var batchChars strings.Builder
+
+		for x := 0; x < f.width; x++ {
+			heat := f.buffer[y*f.width+x]
+
+			// Text mask areas are always empty (negative space)
+			if f.textMask[y][x] {
+				// Flush any pending batch
+				if batchChars.Len() > 0 {
+					r, g, b := hexToRGB(currentColor)
+					fmt.Fprintf(&output, "\033[38;2;%d;%d;%dm%s\033[0m", r, g, b, batchChars.String())
+					batchChars.Reset()
+				}
+				output.WriteString(" ")
+				currentColor = ""
+				continue
+			}
+
+			// Skip very low heat (natural fade to background)
+			if heat < 5 {
+				// Flush any pending batch
+				if batchChars.Len() > 0 {
+					r, g, b := hexToRGB(currentColor)
+					fmt.Fprintf(&output, "\033[38;2;%d;%d;%dm%s\033[0m", r, g, b, batchChars.String())
+					batchChars.Reset()
+				}
+				output.WriteString(" ")
+				currentColor = ""
+				continue
+			}
+
+			// Map heat to character (0-65 → 8 chars)
+			charIndex := (heat * (len(f.chars) - 1)) / 65
+			if charIndex >= len(f.chars) {
+				charIndex = len(f.chars) - 1
+			}
+			char := f.chars[charIndex]
+
+			// Map heat to color from palette
+			colorIndex := (heat * (len(f.palette) - 1)) / 65
+			if colorIndex >= len(f.palette) {
+				colorIndex = len(f.palette) - 1
+			}
+			colorHex := f.palette[colorIndex]
+
+			// If color changed, flush previous batch and start new one
+			if colorHex != currentColor {
+				if batchChars.Len() > 0 {
+					r, g, b := hexToRGB(currentColor)
+					fmt.Fprintf(&output, "\033[38;2;%d;%d;%dm%s\033[0m", r, g, b, batchChars.String())
+					batchChars.Reset()
+				}
+				currentColor = colorHex
+			}
+
+			// Add character to batch
+			batchChars.WriteRune(char)
+		}
+
+		// Flush any remaining batch at end of line
+		if batchChars.Len() > 0 {
+			r, g, b := hexToRGB(currentColor)
+			fmt.Fprintf(&output, "\033[38;2;%d;%d;%dm%s\033[0m", r, g, b, batchChars.String())
+		}
+
+		output.WriteString("\n")
+	}
+
+	// Remove trailing newline
+	result := output.String()
+	if len(result) > 0 && result[len(result)-1] == '\n' {
+		result = result[:len(result)-1]
+	}
+
+	return result
+}

--- a/cmd/syscgo/main.go
+++ b/cmd/syscgo/main.go
@@ -213,7 +213,7 @@ func showHelp() {
 	fmt.Println("  -display           Hold at final state (beam-text only)")
 	fmt.Println()
 	fmt.Println("Effects:")
-	fmt.Println("  fire, matrix, matrix-art, rain, rain-art, fireworks")
+	fmt.Println("  fire, fire-text, matrix, matrix-art, rain, rain-art, fireworks")
 	fmt.Println("  pour, print, beams, beam-text, ring-text, blackhole, aquarium")
 	fmt.Println()
 	fmt.Println("Themes:")
@@ -222,6 +222,7 @@ func showHelp() {
 	fmt.Println()
 	fmt.Println("Examples:")
 	fmt.Println("  syscgo -effect fire -theme nord -duration 30")
+	fmt.Println("  syscgo -effect fire-text -file SYSC.txt -theme dracula -duration 0")
 	fmt.Println("  syscgo -effect aquarium -theme dracula -duration 0")
 	fmt.Println("  syscgo -effect beam-text -file art.txt -auto -display -theme nord")
 	fmt.Println()
@@ -266,6 +267,8 @@ func main() {
 	switch *effect {
 	case "fire":
 		runFire(width, height, *theme, frames)
+	case "fire-text":
+		runFireText(width, height, *theme, *file, frames)
 	case "matrix":
 		runMatrix(width, height, *theme, frames)
 	case "matrix-art":
@@ -295,7 +298,7 @@ func main() {
 		runAquarium(width, height, *theme, frames)
 	default:
 		fmt.Printf("Unknown effect: %s\n", *effect)
-		fmt.Println("Available: fire, matrix, rain, fireworks, pour, print, beams, beam-text, ring-text, blackhole, aquarium")
+		fmt.Println("Available: fire, fire-text, matrix, rain, fireworks, pour, print, beams, beam-text, ring-text, blackhole, aquarium")
 		os.Exit(1)
 	}
 }
@@ -318,6 +321,39 @@ func runFire(width, height int, theme string, frames int) {
 
 		fire.Update()
 		output := fire.Render()
+
+		fmt.Print("\033[H") // Move cursor to top
+		fmt.Print(output)
+		os.Stdout.Sync() // Flush output buffer immediately
+		time.Sleep(50 * time.Millisecond)
+		frame++
+	}
+}
+
+func runFireText(width, height int, theme string, file string, frames int) {
+	// Get theme palette for fire
+	palette := animations.GetFirePalette(theme)
+
+	// Read text from file or use default SYSC.txt
+	text := readTextFile(file)
+
+	// Create fire-text effect
+	fireText := animations.NewFireTextEffect(width, height, palette, text)
+
+	quit := setupKeyboardInterrupt()
+	defer close(quit)
+
+	frame := 0
+	for frames == 0 || frame < frames {
+		// Check for user exit
+		select {
+		case <-quit:
+			return
+		default:
+		}
+
+		fireText.Update()
+		output := fireText.Render()
 
 		fmt.Print("\033[H") // Move cursor to top
 		fmt.Print(output)

--- a/tui/animation.go
+++ b/tui/animation.go
@@ -92,7 +92,7 @@ func LaunchAnimation(animName, theme, file, duration string) error {
 	}
 
 	// Add file if it's for a text-based animation
-	needsFile := []string{"matrix-art", "rain-art", "print", "pour", "beam-text", "ring-text", "blackhole-text", "fireworks"}
+	needsFile := []string{"fire-text", "matrix-art", "rain-art", "print", "pour", "beam-text", "ring-text", "blackhole-text", "fireworks"}
 	for _, effect := range needsFile {
 		if animName == effect {
 			filePath := getAssetPath(file)

--- a/tui/animfactory.go
+++ b/tui/animfactory.go
@@ -72,6 +72,15 @@ func (m *Model) createAnimation() animations.Animation {
 			update: fire.Update,
 		}
 
+	case "fire-text":
+		palette := animations.GetFirePalette(themeName)
+		text := m.loadTextFile(fileName)
+		fireText := animations.NewFireTextEffect(width, height, palette, text)
+		return &AnimationWrapper{
+			render: fireText.Render,
+			update: fireText.Update,
+		}
+
 	case "matrix":
 		palette := animations.GetMatrixPalette(themeName)
 		matrix := animations.NewMatrixEffect(width, height, palette)

--- a/tui/model.go
+++ b/tui/model.go
@@ -138,6 +138,7 @@ func NewModel() Model {
 	return Model{
 		animations: []string{
 			"fire",
+			"fire-text",
 			"matrix",
 			"matrix-art",
 			"rain",

--- a/tui/view.go
+++ b/tui/view.go
@@ -106,7 +106,7 @@ func (m Model) renderSelector(index int, label, value string) string {
 	// Check if this is the File selector and current animation doesn't need a file
 	isFileSelector := (index == 2)
 	animName := m.animations[m.selectedAnimation]
-	needsFile := animName == "matrix-art" || animName == "rain-art" || animName == "pour" ||
+	needsFile := animName == "fire-text" || animName == "matrix-art" || animName == "rain-art" || animName == "pour" ||
 		animName == "print" || animName == "beam-text" || animName == "ring-text" || animName == "blackhole-text"
 
 	// Disable file selector for non-text animations
@@ -185,6 +185,8 @@ func (m Model) renderGuidance() string {
 	switch animName {
 	case "fire":
 		guidance = "Fire effect"
+	case "fire-text":
+		guidance = "Fire with ASCII art"
 	case "matrix", "matrix-art":
 		guidance = "Matrix rain"
 	case "rain", "rain-art":


### PR DESCRIPTION
Implements new fire-text animation where ASCII art is displayed as negative space (empty areas) within fire animation. Fire burns around the text creating a dramatic effect.

Changes:
- Add animations/firetext.go with FireTextEffect implementation
- Text masking system using 2D boolean array to block fire
- Fire propagation respects masked areas (creates negative space)
- Add "fire-text" to TUI animations list and file-based effects
- Add CLI support with runFireText() function
- Update help text and examples to include fire-text
- Remove duplicate hexToRGB function (use existing from fire.go)

The effect centers ASCII art in viewport and prevents fire from entering character positions, creating text shape with empty space.