### PR TITLE
Fix fire-text base to burn from bottom of terminal

### DIFF
--- a/animations/firetext.go
+++ b/animations/firetext.go
@@ -168,6 +168,15 @@ func (f *FireTextEffect) spreadFire(from int) {
 
 // Update advances the fire simulation by one frame
 func (f *FireTextEffect) Update() {
+	// Maintain constant heat source at bottom of terminal (not text base)
+	// This keeps fire burning continuously from the bottom up
+	for x := 0; x < f.width; x++ {
+		bottomIdx := (f.height - 1) * f.width + x
+		if !f.textMask[f.height-1][x] {
+			f.buffer[bottomIdx] = 65 // Maximum heat
+		}
+	}
+
 	// Process all pixels from bottom to top
 	// (Fire spreads upward, must process bottom row first)
 	for y := f.height - 1; y > 0; y-- {


### PR DESCRIPTION
Add constant heat source at bottom row in Update() method. This maintains fire continuously burning from terminal bottom, not just at the base of ASCII art.

Changes:
- Update() now sets bottom row to maximum heat (65) each frame
- Fire propagates upward from terminal bottom through all spaces
- Enclosed spaces within letters fill with fire naturally
- ASCII art remains as negative space throughout animation

Before: Fire died out after brief start, only appeared at text base
After: Fire burns continuously from terminal bottom, filling all gaps