### PR TITLE
Fix pour effect to properly handle ASCII art

### DIFF
--- a/animations/pour.go
+++ b/animations/pour.go
@@ -105,12 +105,25 @@ func (p *PourEffect) init() {
 		startY = 0
 	}
 
+	// Find maximum line width for proper ASCII art alignment
+	maxLineWidth := 0
+	for _, line := range lines {
+		lineLen := len([]rune(line))
+		if lineLen > maxLineWidth {
+			maxLineWidth = lineLen
+		}
+	}
+
+	// Calculate starting X position based on max line width (centers the entire block)
+	baseStartX := (p.width - maxLineWidth) / 2
+	if baseStartX < 0 {
+		baseStartX = 0
+	}
+
 	// Map text to terminal coordinates
 	for lineIdx, line := range lines {
-		startX := (p.width - len(line)) / 2
-		if startX < 0 {
-			startX = 0
-		}
+		// All lines start at the same X position for proper ASCII art alignment
+		startX := baseStartX
 
 		for charIdx, char := range line {
 			if char == ' ' || char == '\t' {

--- a/cmd/syscgo/main.go
+++ b/cmd/syscgo/main.go
@@ -552,8 +552,8 @@ func runPour(width, height int, theme string, file string, frames int) {
 		}
 	}
 
-	// Wrap text to fit terminal width (leave margin for centering)
-	text = wrapText(text, width-10)
+	// Don't wrap text - ASCII art needs to be preserved as-is
+	// The pour effect will handle centering
 
 	// Create pour effect with sample text centered in terminal
 	config := animations.PourConfig{


### PR DESCRIPTION
Fixed two issues preventing ASCII art from displaying correctly:
1. Removed text wrapping that was breaking ASCII art into nonsensical lines
2. Fixed centering to align all lines based on max line width (not per-line)